### PR TITLE
Allow for multiple files

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -122,7 +122,7 @@ def mypy(session: Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or ["src", "tests", "docs/conf.py"]
     session.install(".")
-    session.install("mypy", "pytest")
+    session.install("mypy", "pytest", "typeguard")
     session.run("mypy", *args)
     if not session.posargs:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")

--- a/src/nbpreview/__main__.py
+++ b/src/nbpreview/__main__.py
@@ -1,6 +1,7 @@
 """Command-line interface."""
 import os
 import pathlib
+import typing
 from pathlib import Path
 from sys import stdin, stdout
 from typing import IO, AnyStr, Iterator, List, Literal, Optional, Sequence, Union
@@ -17,6 +18,13 @@ from nbpreview.component.content.output.result import drawing
 from nbpreview.component.content.output.result.drawing import ImageDrawingEnum
 from nbpreview.notebook import Notebook
 from nbpreview.parameters import ColorSystemEnum
+
+# Prevent typeguard from being a non-development dependency
+# https://github.com/agronholm/typeguard/issues/179#issue-832697465
+if typing.TYPE_CHECKING:  # pragma: no cover
+    from typeguard import typeguard_ignore
+else:
+    from typing import no_type_check as typeguard_ignore
 
 app = typer.Typer()
 traceback.install(theme="material")
@@ -128,6 +136,9 @@ def _create_file_title(path: Path, width: int) -> str:
     return title
 
 
+# Typeguard gets confused with decorators that change the return type
+# https://github.com/agronholm/typeguard/issues/115
+@typeguard_ignore
 @console.group()
 def _title_output(
     renderable: RenderableType,

--- a/src/nbpreview/notebook.py
+++ b/src/nbpreview/notebook.py
@@ -292,7 +292,10 @@ class Notebook:
         """Create Notebook from notebook file."""
         try:
             notebook_node = nbformat.read(file, as_version=4)
-        except AttributeError as exception:
+        except (
+            AttributeError,
+            UnicodeDecodeError,  # Windows failures when reading invalid files
+        ) as exception:
             raise errors.InvalidNotebookError from exception
         relative_dir = (
             pathlib.Path.cwd()

--- a/src/nbpreview/notebook.py
+++ b/src/nbpreview/notebook.py
@@ -40,7 +40,7 @@ else:
     KeepOpenFileType = _KeepOpenFile()
 
 
-def _pick_option(option: Optional[bool], detector: bool) -> bool:
+def pick_option(option: Optional[bool], detector: bool) -> bool:
     """Select a render option.
 
     Args:
@@ -330,15 +330,15 @@ class Notebook:
         Yields:
             Iterator[RenderResult]: The
         """
-        plain = _pick_option(self.plain, detector=not options.is_terminal)
-        unicode = _pick_option(
+        plain = pick_option(self.plain, detector=not options.is_terminal)
+        unicode = pick_option(
             self.unicode, detector=not options.legacy_windows and not options.ascii_only
         )
-        hyperlinks = _pick_option(
+        hyperlinks = pick_option(
             self.hyperlinks, detector=not options.legacy_windows and options.is_terminal
         )
-        images = _pick_option(self.images, detector=options.is_terminal)
-        color = _pick_option(self.color, detector=options.is_terminal)
+        images = pick_option(self.images, detector=options.is_terminal)
+        color = pick_option(self.color, detector=options.is_terminal)
         image_drawing = _pick_image_drawing(
             self.image_drawing, unicode=unicode, color=color
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import contextlib
 import io
 import itertools
+import os
 import pathlib
 import re
 import tempfile
@@ -235,7 +236,7 @@ def expected_output(
     expected_output_template = env.get_template(expected_output_file)
     project_dir = pathlib.Path(__file__).parent.parent.resolve()
     expected_output = expected_output_template.render(
-        tempfile_path=tempfile_path, project_dir=project_dir
+        tempfile_path=os.fsdecode(tempfile_path), project_dir=project_dir
     )
     return remove_link_ids(expected_output)
 


### PR DESCRIPTION
This PR adds the ability to take in multiple files for the `FILES`﻿argument.

```sh
% nbpreview notebook_1.ipynb notebook_2.ipynb
```

This is most useful when used with wildcards, such as when the user is trying to render a directory of notebooks.

```sh
% nbpreview notebooks/*.ipynb
```

To distinguish each file, nbpreview will draw borders around each render along with a title that has the file path.


```txt
┏━ /var/folders/83/rh6w710n4c7flyxf9pg0k9400000gn/T/tmph8w0mvor ━━━━━━━━━━━━━━━┓
┃                                                                              ┃
┃       ╭───────────────────────────────────────────────────────────────────╮  ┃
┃  [2]: │ def foo(x: float, y: float) -> float:                             │  ┃
┃       │     return x + y                                                  │  ┃
┃       ╰───────────────────────────────────────────────────────────────────╯  ┃
┃                                                                              ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

┏━ /var/folders/83/rh6w710n4c7flyxf9pg0k9400000gn/T/tmph8w0mvor ━━━━━━━━━━━━━━━┓
┃                                                                              ┃
┃       ╭───────────────────────────────────────────────────────────────────╮  ┃
┃  [2]: │ def foo(x: float, y: float) -> float:                             │  ┃
┃       │     return x + y                                                  │  ┃
┃       ╰───────────────────────────────────────────────────────────────────╯  ┃
┃                                                                              ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```

The border will not render when used with the `--plain` option, which is also used automatically when output is piped to stdout.

This even allows for some weird behavior, where you can read from stdin and a file at the same time, and render them both.

```sh
% cat notebook_1.ipynb | nbpreview notebook_2.ipynb
```

If multiple files are given, and some are invalid—whether this be because they are not notebook or are invalid notebooks—nbpreview will still render the notebooks it is able to, along with a warning message for those it failed on.

Closes #335