### PR TITLE
Move parameter validation and transformation to parameter callbacks

### DIFF
--- a/src/nbpreview/__main__.py
+++ b/src/nbpreview/__main__.py
@@ -284,7 +284,7 @@ def main(
 
     else:
         message = _make_invalid_notebook_message(file)
-        raise typer.BadParameter(message, param_hint="FILE")
+        raise typer.BadParameter(message, param_hint="'FILE...'")
 
 
 typer_click_object = typer.main.get_command(app)

--- a/src/nbpreview/__main__.py
+++ b/src/nbpreview/__main__.py
@@ -4,7 +4,7 @@ import pathlib
 import typing
 from pathlib import Path
 from sys import stdin, stdout
-from typing import IO, AnyStr, Iterator, List, Literal, Optional, Sequence, Union
+from typing import IO, AnyStr, Iterator, List, Optional, Sequence, Union
 
 import click
 import nbformat
@@ -166,26 +166,16 @@ def main(
 ) -> None:
     """Render a Jupyter Notebook in the terminal."""
     no_color = not color if color is not None else color
-    _color_system: Union[
-        Literal["auto", "standard", "256", "truecolor", "windows"], None
-    ]
-    if color_system is None:
-        _color_system = "auto"
-    elif color_system == "none":
-        _color_system = None
-    else:
-        _color_system = color_system.value
+    files = not no_files
+    negative_space = not positive_space
+    translated_theme = parameters.translate_theme(theme)
 
     output_console = console.Console(
         width=width,
         no_color=no_color,
         emoji=unicode if unicode is not None else True,
-        color_system=_color_system,
+        color_system=color_system,  # type: ignore[arg-type]
     )
-
-    files = not no_files
-    negative_space = not positive_space
-    translated_theme = parameters.translate_theme(theme)
 
     has_multiple_files = 1 < len(file)
     successful_render = False

--- a/src/nbpreview/__main__.py
+++ b/src/nbpreview/__main__.py
@@ -14,10 +14,8 @@ from rich.console import Capture, Console, RenderableType
 from rich.text import Text
 
 from nbpreview import errors, notebook, parameters
-from nbpreview.component.content.output.result import drawing
-from nbpreview.component.content.output.result.drawing import ImageDrawingEnum
 from nbpreview.notebook import Notebook
-from nbpreview.parameters import ColorSystemEnum
+from nbpreview.option_values import ColorSystemEnum, ImageDrawingEnum
 
 # Prevent typeguard from being a non-development dependency
 # https://github.com/agronholm/typeguard/issues/179#issue-832697465
@@ -46,22 +44,6 @@ def _detect_no_color() -> Union[bool, None]:
     )
     force_no_color = any(no_color_variables)
     return force_no_color
-
-
-def _check_image_drawing_option(image_drawing: Union[ImageDrawingEnum, None]) -> None:
-    """Check if the image drawing option is valid."""
-    if image_drawing == drawing.ImageDrawingEnum.BLOCK:
-        try:
-            import terminedia  # noqa: F401
-        except ModuleNotFoundError as exception:
-            message = (
-                f"--image-drawing='{image_drawing.value}' cannot be"
-                " used on this system. This might be because it is"
-                " being run on Windows."
-            )
-            raise typer.BadParameter(
-                message=message, param_hint="image-drawing"
-            ) from exception
 
 
 def _detect_paging(
@@ -221,7 +203,6 @@ def main(
         color_system=_color_system,
     )
 
-    _check_image_drawing_option(image_drawing)
     files = not no_files
     negative_space = not positive_space
     translated_theme = parameters.translate_theme(theme)

--- a/src/nbpreview/__main__.py
+++ b/src/nbpreview/__main__.py
@@ -168,7 +168,6 @@ def main(
     no_color = not color if color is not None else color
     files = not no_files
     negative_space = not positive_space
-    translated_theme = parameters.translate_theme(theme)
 
     output_console = console.Console(
         width=width,
@@ -187,7 +186,7 @@ def main(
                 try:
                     rendered_file = notebook.Notebook.from_file(
                         opened_notebook_file,
-                        theme=translated_theme,
+                        theme=theme,
                         hide_output=hide_output,
                         plain=plain,
                         unicode=unicode,

--- a/src/nbpreview/__main__.py
+++ b/src/nbpreview/__main__.py
@@ -28,24 +28,6 @@ app = typer.Typer()
 traceback.install(theme="material")
 
 
-def _envvar_to_bool(envvar: str) -> bool:
-    """Convert environmental variable values to bool."""
-    envvar_value = os.environ.get(envvar, False)
-    envvar_bool = bool(envvar_value) and (envvar != "0") and (envvar.lower() != "false")
-    return envvar_bool
-
-
-def _detect_no_color() -> Union[bool, None]:
-    """Detect if color should be used."""
-    no_color_variables = (
-        _envvar_to_bool("NO_COLOR"),
-        _envvar_to_bool("NBPREVIEW_NO_COLOR"),
-        os.environ.get("TERM", "smart").lower() == "dumb",
-    )
-    force_no_color = any(no_color_variables)
-    return force_no_color
-
-
 def _detect_paging(
     paging: Union[bool, None], rendered_notebook: str, console: Console
 ) -> bool:
@@ -183,8 +165,6 @@ def main(
     paging: Optional[bool] = parameters.paging_option,
 ) -> None:
     """Render a Jupyter Notebook in the terminal."""
-    if color is None and _detect_no_color():
-        color = False
     no_color = not color if color is not None else color
     _color_system: Union[
         Literal["auto", "standard", "256", "truecolor", "windows"], None

--- a/src/nbpreview/component/content/output/result/drawing.py
+++ b/src/nbpreview/component/content/output/result/drawing.py
@@ -19,8 +19,8 @@ from rich.console import Console, ConsoleOptions, RenderResult
 from rich.measure import Measurement
 from rich.text import Text
 
-from nbpreview import parameters
 from nbpreview.data import Data
+from nbpreview.option_values import ImageDrawingEnum
 
 # terminedia depends on fcntl, which is not present on Windows platforms
 try:
@@ -34,15 +34,6 @@ class Size(typing.NamedTuple):
 
     x: Union[float, None]
     y: Union[float, None]
-
-
-@enum.unique
-class ImageDrawingEnum(str, parameters.LowerNameEnum):
-    """Image drawing types."""
-
-    BLOCK = enum.auto()
-    CHARACTER = enum.auto()
-    BRAILLE = enum.auto()
 
 
 ImageDrawing = Union[ImageDrawingEnum, Literal["block", "character", "braille"]]

--- a/src/nbpreview/option_values.py
+++ b/src/nbpreview/option_values.py
@@ -1,0 +1,36 @@
+"""Enums representing option values."""
+import enum
+from typing import Any, List, Literal
+
+
+class LowerNameEnum(enum.Enum):
+    """Enum base class that sets value to lowercase version of name."""
+
+    def _generate_next_value_(  # type: ignore[override,misc]
+        name: str,  # noqa: B902,N805
+        start: int,
+        count: int,
+        last_values: List[Any],
+    ) -> str:
+        """Set member's values as their lowercase name."""
+        return name.lower()
+
+
+@enum.unique
+class ColorSystemEnum(str, LowerNameEnum):
+    """The color systems supported by terminals."""
+
+    STANDARD: Literal["standard"] = enum.auto()  # type: ignore[assignment]
+    EIGHT_BIT: Literal["256"] = "256"
+    TRUECOLOR: Literal["truecolor"] = enum.auto()  # type: ignore[assignment]
+    WINDOWS: Literal["windows"] = enum.auto()  # type: ignore[assignment]
+    NONE: Literal["none"] = enum.auto()  # type: ignore[assignment]
+
+
+@enum.unique
+class ImageDrawingEnum(str, LowerNameEnum):
+    """Image drawing types."""
+
+    BLOCK = enum.auto()
+    CHARACTER = enum.auto()
+    BRAILLE = enum.auto()

--- a/src/nbpreview/parameters.py
+++ b/src/nbpreview/parameters.py
@@ -1,12 +1,11 @@
 """Command line interface parameters."""
-import enum
 import itertools
 import pathlib
 import sys
 import textwrap
 import typing
 from pathlib import Path
-from typing import Any, Callable, Iterable, List, Literal, Optional, Type, Union
+from typing import Any, Callable, Iterable, List, Optional, Type, Union
 
 import typer
 from click import Context, Parameter
@@ -15,29 +14,6 @@ from pygments import styles
 from rich import box, console, panel, syntax
 
 from nbpreview import __version__
-
-
-class LowerNameEnum(enum.Enum):
-    """Enum base class that sets value to lowercase version of name."""
-
-    def _generate_next_value_(  # type: ignore[override,misc]
-        name: str,  # noqa: B902,N805
-        start: int,
-        count: int,
-        last_values: List[Any],
-    ) -> str:
-        """Set member's values as their lowercase name."""
-        return name.lower()
-
-
-class ColorSystemEnum(str, LowerNameEnum):
-    """The color systems supported by terminals."""
-
-    STANDARD: Literal["standard"] = enum.auto()  # type: ignore[assignment]
-    EIGHT_BIT: Literal["256"] = "256"
-    TRUECOLOR: Literal["truecolor"] = enum.auto()  # type: ignore[assignment]
-    WINDOWS: Literal["windows"] = enum.auto()  # type: ignore[assignment]
-    NONE: Literal["none"] = enum.auto()  # type: ignore[assignment]
 
 
 def version_callback(value: Optional[bool] = None) -> None:

--- a/src/nbpreview/parameters.py
+++ b/src/nbpreview/parameters.py
@@ -54,18 +54,18 @@ def complete_theme(ctx: Context, param: Parameter, incomplete: str) -> List[str]
 
 
 @typing.overload
-def translate_theme(theme_argument: str) -> str:
+def _theme_callback(theme_argument: str) -> str:
     """Convert theme argument to one recognized by rich."""
     ...
 
 
 @typing.overload
-def translate_theme(theme_argument: None) -> None:
+def _theme_callback(theme_argument: None) -> None:
     """Convert theme argument to one recognized by rich."""
     ...
 
 
-def translate_theme(theme_argument: Union[str, None]) -> Union[str, None]:
+def _theme_callback(theme_argument: Union[str, None]) -> Union[str, None]:
     """Convert theme argument to one recognized by rich."""
     translated_theme: Union[str, None]
     if theme_argument is not None:
@@ -82,7 +82,7 @@ def translate_theme(theme_argument: Union[str, None]) -> Union[str, None]:
     return translated_theme
 
 
-def list_themes_callback(value: Optional[bool] = None) -> None:
+def _list_themes_callback(value: Optional[bool] = None) -> None:
     """Render a preview of all available themes."""
     example_code = textwrap.dedent(
         '''\
@@ -108,7 +108,7 @@ def list_themes_callback(value: Optional[bool] = None) -> None:
         stdout_console = console.Console(file=sys.stdout)
         panel_width = min(stdout_console.width, 88)
         for theme in _get_all_available_themes(list_duplicate_alias=False):
-            translated_theme = translate_theme(theme)
+            translated_theme = _theme_callback(theme)
             theme_title = (
                 f"{theme} / ansi_{theme}" if theme in ("dark", "light") else theme
             )
@@ -303,13 +303,14 @@ theme_option = typer.Option(
     " terminal. Call --list-themes to preview all available themes.",
     envvar="NBPREVIEW_THEME",
     shell_complete=complete_theme,
+    callback=_theme_callback,
 )
 list_themes_option = typer.Option(
     None,
     "--list-themes",
     "--lt",
     help="Display a preview of all available themes.",
-    callback=list_themes_callback,
+    callback=_list_themes_callback,
     is_eager=True,
 )
 hide_output_option = typer.Option(

--- a/src/nbpreview/parameters.py
+++ b/src/nbpreview/parameters.py
@@ -6,7 +6,7 @@ import sys
 import textwrap
 import typing
 from pathlib import Path
-from typing import Any, Callable, Iterable, List, Optional, Type, Union
+from typing import Any, Callable, Iterable, List, Literal, Optional, Type, Union
 
 import typer
 from click import Context, Parameter
@@ -15,7 +15,7 @@ from pygments import styles
 from rich import box, console, panel, syntax
 
 from nbpreview import __version__, option_values
-from nbpreview.option_values import ImageDrawingEnum
+from nbpreview.option_values import ColorSystemEnum, ImageDrawingEnum
 
 
 def version_callback(value: Optional[bool] = None) -> None:
@@ -182,10 +182,28 @@ def _detect_no_color() -> Union[bool, None]:
     return force_no_color
 
 
-def _color_option_callback(color_value: Optional[bool]) -> Union[bool, None]:
+def _color_option_callback(color_value: Union[bool, None]) -> Union[bool, None]:
     """Detect if any no color environmental variables are set."""
     color = False if color_value is None and _detect_no_color() else color_value
     return color
+
+
+def _color_system_callback(
+    color_system_value: Union[ColorSystemEnum, None]
+) -> Union[Literal["auto", "standard", "256", "truecolor", "windows"], None]:
+    """Translate the color system values to ones rich understands."""
+    color_system: Union[
+        Literal["auto", "standard", "256", "truecolor", "windows"], None
+    ]
+    if color_system_value is None:
+        color_system = "auto"
+
+    elif color_system_value == "none":
+        color_system = None
+
+    else:
+        color_system = color_system_value.value
+    return color_system
 
 
 def stdin_path_argument(
@@ -406,6 +424,7 @@ color_system_option = typer.Option(
     help="The type of color system to use.",
     envvar="NBPREVIEW_COLOR_SYSTEM",
     case_sensitive=False,
+    callback=_color_system_callback,
 )
 line_numbers_option = typer.Option(
     False,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -348,7 +348,7 @@ def test_exit_invalid_file_output(
     expected_output = (
         "Usage: main [OPTIONS] [FILE]..."
         "\nTry 'main --help' for help."
-        f"\n\nError: Invalid value for FILE: {invalid_path}"
+        f"\n\nError: Invalid value for 'FILE...': {invalid_path}"
         " is not a valid Jupyter Notebook path.\n"
     )
     assert output == expected_output
@@ -479,7 +479,7 @@ def test_raise_no_source(
     expected_output = (
         "Usage: main [OPTIONS] [FILE]..."
         "\nTry 'main --help' for help."
-        "\n\nError: Invalid value for FILE:"
+        "\n\nError: Invalid value for 'FILE...':"
         f" {notebook_path} is not a valid Jupyter Notebook path.\n"
     )
     assert output == expected_output
@@ -499,7 +499,7 @@ def test_raise_no_output(
     expected_output = (
         "Usage: main [OPTIONS] [FILE]...\nTry 'main -"
         "-help' for help.\n\nError: Invalid value f"
-        f"or FILE: {notebook_path} is not a v"
+        f"or 'FILE...': {notebook_path} is not a v"
         "alid Jupyter Notebook path.\n"
     )
     assert output == expected_output
@@ -758,8 +758,8 @@ def test_message_failed_terminedia_import(cli_arg: Callable[..., str]) -> None:
     expected_output = (
         "Usage: main [OPTIONS] [FILE]..."
         "\nTry 'main --help' for help."
-        "\n\nError: Invalid value for image-drawing:"
-        " --image-drawing='block' cannot be used on this system."
+        "\n\nError: Invalid value for '--image-drawing' / '--id':"
+        " 'block' cannot be used on this system."
         " This might be because it is being run on Windows.\n"
     )
     assert output == expected_output
@@ -1311,7 +1311,7 @@ def test_multiple_files_all_fail_message(
     expected_output = (
         "Usage: main [OPTIONS] [FILE]...\nTry 'mai"
         "n --help' for help.\n\nError: Invalid valu"
-        f"e for FILE: {invalid_path}, {invalid_path}"
+        f"e for 'FILE...': {invalid_path}, {invalid_path}"
         " are not a valid Jupyter Notebook paths.\n"
     )
     assert output == expected_output


### PR DESCRIPTION
In an effort to decouple the parameter from the rendering logic, move all possible CLI parameter validation and transformation to Click/Typer parameter callbacks.

Closes #343
