### PR TITLE
Fix color system not defaulting to auto

### DIFF
--- a/src/nbpreview/option_values.py
+++ b/src/nbpreview/option_values.py
@@ -25,6 +25,8 @@ class ColorSystemEnum(str, LowerNameEnum):
     TRUECOLOR: Literal["truecolor"] = enum.auto()  # type: ignore[assignment]
     WINDOWS: Literal["windows"] = enum.auto()  # type: ignore[assignment]
     NONE: Literal["none"] = enum.auto()  # type: ignore[assignment]
+    # Add AUTO because callbacks must return values associated with types
+    AUTO: Literal["auto"] = enum.auto()  # type: ignore[assignment]
 
 
 @enum.unique

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -535,6 +535,21 @@ def mock_terminal(mocker: MockerFixture) -> Iterator[Mock]:
     yield mock
 
 
+def test_default_color_system_auto(
+    runner: CliRunner,
+    mocker: MockerFixture,
+    notebook_path: Path,
+) -> None:
+    """Its default value is 'auto'."""
+    mock = mocker.patch("nbpreview.__main__.console.Console")
+    runner.invoke(
+        __main__.typer_click_object, args=[os.fsdecode(notebook_path)], color=True
+    )
+    # console.Console is called multiple times, first time should be
+    # console representing terminal
+    assert mock.call_args_list[0].kwargs["color_system"] == "auto"
+
+
 def test_list_themes(
     runner: CliRunner,
     mocker: MockerFixture,


### PR DESCRIPTION
Hotfix for regression introduced in #349, where default color system was set to `None`—meaning notebooks were not rendering with color.

Typer can silently fail when the callback's type does not align with the original type hint of the related parameter.
