### PR TITLE
Release 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nbpreview"
-version = "0.5.0"
+version = "0.6.0"
 description = "nbpreview"
 authors = ["Paulo S. Costa <Paulo.S.Costa5@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- :heavy_plus_sign: Add click-help-colors
- :wrench: Ignore missing click-help-colors imports
- :white_check_mark: Test help colors
- :sparkles: Color help message
- :bookmark: Bump to 0.6.0
