### PR TITLE
Add PyPI issues link

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 
 [tool.poetry.urls]
 Changelog = "https://github.com/paw-lu/nbpreview/releases"
+Issues = "https://github.com/paw-lu/nbpreview/issues"
 
 [tool.poetry.dependencies]
 python = "^3.8.0"


### PR DESCRIPTION
PyPI has additional support for other links. Adds issues link, which should render with a bug icon on PyPI.

Closes #170
