### PR TITLE
Switch license to use GitHub default plaintext file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-# MIT License
+MIT License
 
-Copyright (c) `2022` `Paulo S. Costa`
+Copyright (c) 2022 Paulo S. Costa
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,3 +1,7 @@
-```{include} ../LICENSE.md
+# License
 
+```{literalinclude} ../LICENSE
+---
+language: none
+---
 ```


### PR DESCRIPTION
Cookiecutter plans to use original GitHub default for license file. Convert from markdown to GitHub's plaintext to stay in sync.
