### PR TITLE
Explicitly enable dollarmath for MyST

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ intersphinx_mapping = {
 }
 autodoc_typehints = "description"
 myst_heading_anchors = 3
+myst_enable_extensions = ["dollarmath"]
 html_theme = "furo"
 pygments_style = "material"
 pygments_dark_style = "material"


### PR DESCRIPTION
[MyST 0.17.0 disbaled dollarmath by default](https://myst-parser.readthedocs.io/en/latest/develop/_changelog.html#dollarmath-is-now-disabled-by-default), which broke some rendering when #430 and #448 was merged.

Explicitly enable it
