### PR TITLE
Update term-image package name in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "lxml": ("https://lxml.de/apidoc/", None),
     "rich": ("https://rich.readthedocs.io/en/latest/", None),
-    "term-img": ("https://term-img.readthedocs.io/en/latest/", None),
+    "term-image": ("https://term-image.readthedocs.io/en/latest/", None),
 }
 autodoc_typehints = "description"
 myst_heading_anchors = 3

--- a/docs/features.md
+++ b/docs/features.md
@@ -320,7 +320,7 @@ file: _static/examples/html/markdown.html
 ## Images
 
 Thanks to [Picharsso]
-and {class}`term-img <term_img.image.TermImage>`,
+and {class}`term-image <term_img.image.TermImage>`,
 nbpreview renders images.
 
 ### Drawing types


### PR DESCRIPTION
term-image recently changed it's name from term-img. Update docs and links to reflect the change.
