### PR TITLE
Do not shadow InitVar names

### DIFF
--- a/src/nbpreview/component/row.py
+++ b/src/nbpreview/component/row.py
@@ -31,8 +31,8 @@ class Row:
 
     def __post_init__(self, execution: Optional[Execution]) -> None:
         """Initialize the execution indicator."""
-        self.execution: Union[Execution, str]
-        self.execution = execution_indicator.choose_execution(execution)
+        self.execution_indicator: Union[Execution, str]
+        self.execution_indicator = execution_indicator.choose_execution(execution)
 
     def to_table_row(self) -> TableRow:
         """Convert to row for table usage."""
@@ -40,7 +40,7 @@ class Row:
         if self.plain:
             table_row = (self.content,)
         else:
-            table_row = (self.execution, self.content)
+            table_row = (self.execution_indicator, self.content)
         return table_row
 
 

--- a/src/nbpreview/notebook.py
+++ b/src/nbpreview/notebook.py
@@ -267,7 +267,7 @@ class Notebook:
         self.cells = self.notebook_node.get(
             "cells", nbformat.from_dict([])  # type: ignore[no-untyped-call]
         )
-        self.relative_dir = (
+        self.resolved_relative_dir = (
             pathlib.Path().resolve() if relative_dir is None else relative_dir
         )
         try:
@@ -425,7 +425,7 @@ class Notebook:
             image_drawing=image_drawing,
             color=color,
             negative_space=self.negative_space,
-            relative_dir=self.relative_dir,
+            relative_dir=self.resolved_relative_dir,
             line_numbers=self.line_numbers,
             code_wrap=self.code_wrap,
         )


### PR DESCRIPTION
Previously I assign to attribute names that are used as a dataclass `InitVar`. This is now unsupported by mypy since 0.960. Renaming the attributes to have their own unique names, and not shadow the name of the `InitVar`.

See

- https://github.com/python/mypy/pull/12798
- https://github.com/python/mypy/issues/12877#issuecomment-1139551686
