### PR TITLE
Update to account for changes in term image api

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -320,7 +320,7 @@ file: _static/examples/html/markdown.html
 ## Images
 
 Thanks to [Picharsso]
-and {class}`term-image <term_img.image.TermImage>`,
+and {class}`term-image <term_img.image.BaseImage>`,
 nbpreview renders images.
 
 ### Drawing types

--- a/src/nbpreview/component/content/output/result/drawing.py
+++ b/src/nbpreview/component/content/output/result/drawing.py
@@ -263,7 +263,7 @@ def _render_block_drawing(
     rendered_unicode_drawing: Tuple[Text, ...]
     try:
         pil_image = PIL.Image.open(io.BytesIO(image))
-        block_image = term_image.TermImage(pil_image)
+        block_image = term_image.AutoImage(pil_image)
         block_image.set_size(maxsize=(max_width, max_height))
         string_image = str(block_image)
         pil_image.close()


### PR DESCRIPTION
Not sure if there are other parts of nbpreview affected by changes in the term_image API, but the updates in this PR appear to fix #791.