### PR TITLE
dataframe_display_type: handle case where head or body are None

### DIFF
--- a/src/nbpreview/component/content/output/result/display_data.py
+++ b/src/nbpreview/component/content/output/result/display_data.py
@@ -311,6 +311,8 @@ class DataFrameDisplay(DisplayData):
         try:
             style_element, *non_style_elements = html_element.head.iterchildren()
             *non_table_elements, table_element = html_element.body.iterchildren()
+        except AttributeError:
+            return None
         except (ValueError, IndexError):
             pass
         else:


### PR DESCRIPTION
When a notebook contains some narrow <b>…</b> snippets, html.fromstring(content) returns an element with no `<head>/<body>`.
This PR handle this case by having dataframe_display_type() return None in this case.